### PR TITLE
Make it work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # tycho-sonar-jacoco
+
+This works for me and shows 100% coverage in 4 tests in SonarQube:
+
+	$ mvn clean install
+	$ mvn jacoco:report -Djacoco.dataFile=../../target/jacoco.exec
+	$ mvn sonar:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
     <!-- ############## -->
     <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-	<sonar.jacoco.reportPaths>../../target/jacoco.exec</sonar.jacoco.reportPaths>
 	<jacoco.destFile>../../target/jacoco.exec</jacoco.destFile>
 	<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 	<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -124,7 +123,7 @@
             </goals>
             <configuration>
               <append>true</append>
-			  <destFile>${sonar.jacoco.reportPaths}</destFile>
+			  <destFile>${jacoco.destFile}</destFile>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,11 @@
     <!-- ############## -->
     <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-    <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml,target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+	<sonar.jacoco.reportPaths>../../target/jacoco.exec</sonar.jacoco.reportPaths>
+	<jacoco.destFile>../../target/jacoco.exec</jacoco.destFile>
+	<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+	<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+	<sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <repositories>
@@ -120,6 +124,7 @@
             </goals>
             <configuration>
               <append>true</append>
+			  <destFile>${sonar.jacoco.reportPaths}</destFile>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This works for me. I had to adapt your pom slightly, and you have to run the Jacoco report manually.
Having to run jacoco:report manually is not nice, but it works. This is because Tycho would create the report too early in the plugin's target, before the test is even run.